### PR TITLE
project name fix

### DIFF
--- a/catschedDashboard.Rproj
+++ b/catschedDashboard.Rproj
@@ -12,3 +12,5 @@ Encoding: UTF-8
 
 RnwWeave: Sweave
 LaTeX: pdfLaTeX
+
+ProjectName: catschedDashboard


### PR DESCRIPTION
Fixing the name of the project so the deployment to Shiny doesn't duplicate the app