### PR TITLE
Correct TARGET variable and add trigger

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,12 +5,19 @@ permissions:
   
 on:
   workflow_dispatch:
-    
+  push:
+    branches:
+      - 'main'
+    paths:
+      - 'Containerfile'
+      - '**.R'
+      - 'img/*'
+  
 env:
   REGISTRY: ghcr.io
   USERNAME: ${{ github.actor }}
   TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  TARGET: '${{ github.repository_owner }}/crf-dashboard'
+  TARGET: '${{ github.respository }}'
   
 jobs:
   build:


### PR DESCRIPTION
I ran the action and discovered it had the old repository name hardcoded, yielding an incorrectly named container: https://github.com/orgs/DavidsonCollege-DataScience/packages/container/package/crf-dashboard 

Fixes typo in repository reference for TARGET environment variable. Adds push triggered launch.

